### PR TITLE
Improve code to connect to emulators on android

### DIFF
--- a/fundamentals/android/auth-email-password/Notes/app/src/main/AndroidManifest.xml
+++ b/fundamentals/android/auth-email-password/Notes/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Notes"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31"
         android:name = ".NotesHiltApp">
         <activity

--- a/fundamentals/android/auth-email-password/Notes/app/src/main/java/com/notes/app/NotesActivity.kt
+++ b/fundamentals/android/auth-email-password/Notes/app/src/main/java/com/notes/app/NotesActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -18,7 +19,8 @@ class NotesActivity : ComponentActivity() {
 
     private fun configureFirebaseServices() {
         if (BuildConfig.DEBUG) {
-            Firebase.auth.useEmulator("127.0.0.1", 9099)
+            Firebase.auth.useEmulator(LOCALHOST, AUTH_PORT)
+            Firebase.firestore.useEmulator(LOCALHOST, FIRESTORE_PORT)
         }
     }
 }

--- a/fundamentals/android/auth-email-password/Notes/app/src/main/java/com/notes/app/NotesRoutes.kt
+++ b/fundamentals/android/auth-email-password/Notes/app/src/main/java/com/notes/app/NotesRoutes.kt
@@ -9,3 +9,7 @@ const val SPLASH_SCREEN = "SplashScreen"
 const val NOTE_ID = "noteId"
 const val NOTE_DEFAULT_ID = "-1"
 const val NOTE_ID_ARG = "?$NOTE_ID={$NOTE_ID}"
+
+const val LOCALHOST = "10.0.2.2"
+const val AUTH_PORT = 9099
+const val FIRESTORE_PORT = 8080


### PR DESCRIPTION
- Create localhost and ports constants for Auth and Firestore;
- Use them in `NotesActivity` instead of hardcoded strings;
- Add `usesCleartextTraffic` to `AndroidManifest`, as it is required for most recent devices to be able to access http routes;