### PR TITLE
Add Anonymous Authentication and Account Center to Android samples

### DIFF
--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/NotesApp.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/NotesApp.kt
@@ -14,6 +14,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.notes.app.screens.account_center.AccountCenterScreen
 import com.notes.app.screens.note.NoteScreen
 import com.notes.app.screens.notes_list.NotesListScreen
 import com.notes.app.screens.sign_in.SignInScreen
@@ -76,5 +77,9 @@ fun NavGraphBuilder.notesGraph(appState: NotesAppState) {
     
     composable(SPLASH_SCREEN) {
         SplashScreen(openAndPopUp = { route, popUp -> appState.navigateAndPopUp(route, popUp) })
+    }
+
+    composable(ACCOUNT_CENTER_SCREEN) {
+        AccountCenterScreen(restartApp = { route -> appState.clearAndNavigate(route) })
     }
 }

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/NotesRoutes.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/NotesRoutes.kt
@@ -5,6 +5,7 @@ const val NOTE_SCREEN = "NoteScreen"
 const val SIGN_IN_SCREEN = "SignInScreen"
 const val SIGN_UP_SCREEN = "SignUpScreen"
 const val SPLASH_SCREEN = "SplashScreen"
+const val ACCOUNT_CENTER_SCREEN = "AccountCenterScreen"
 
 const val NOTE_ID = "noteId"
 const val NOTE_DEFAULT_ID = "-1"

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/User.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/User.kt
@@ -1,5 +1,9 @@
 package com.notes.app.model
 
 data class User(
-    val id: String = ""
+    val id: String = "",
+    val email: String = "",
+    val provider: String = "",
+    val displayName: String = "",
+    val isAnonymous: Boolean = true
 )

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/AccountService.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/AccountService.kt
@@ -7,8 +7,9 @@ interface AccountService {
     val currentUser: Flow<User?>
     val currentUserId: String
     fun hasUser(): Boolean
+    suspend fun createAnonymousAccount()
+    suspend fun linkAccount(email: String, password: String)
     suspend fun signIn(email: String, password: String)
-    suspend fun signUp(email: String, password: String)
     suspend fun signOut()
     suspend fun deleteAccount()
 }

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/AccountService.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/AccountService.kt
@@ -7,6 +7,7 @@ interface AccountService {
     val currentUser: Flow<User?>
     val currentUserId: String
     fun hasUser(): Boolean
+    fun isAnonymousUser(): Boolean
     suspend fun createAnonymousAccount()
     suspend fun linkAccount(email: String, password: String)
     suspend fun signIn(email: String, password: String)

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/AccountService.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/AccountService.kt
@@ -8,6 +8,7 @@ interface AccountService {
     val currentUserId: String
     fun hasUser(): Boolean
     suspend fun createAnonymousAccount()
+    suspend fun getUserProfile(): User
     suspend fun updateDisplayName(newDisplayName: String)
     suspend fun linkAccount(email: String, password: String)
     suspend fun signIn(email: String, password: String)

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/AccountService.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/AccountService.kt
@@ -7,8 +7,8 @@ interface AccountService {
     val currentUser: Flow<User?>
     val currentUserId: String
     fun hasUser(): Boolean
-    fun isAnonymousUser(): Boolean
     suspend fun createAnonymousAccount()
+    suspend fun updateDisplayName(newDisplayName: String)
     suspend fun linkAccount(email: String, password: String)
     suspend fun signIn(email: String, password: String)
     suspend fun signOut()

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/AccountService.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/AccountService.kt
@@ -7,8 +7,8 @@ interface AccountService {
     val currentUser: Flow<User?>
     val currentUserId: String
     fun hasUser(): Boolean
+    fun getUserProfile(): User
     suspend fun createAnonymousAccount()
-    suspend fun getUserProfile(): User
     suspend fun updateDisplayName(newDisplayName: String)
     suspend fun linkAccount(email: String, password: String)
     suspend fun signIn(email: String, password: String)

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/impl/AccountServiceImpl.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/impl/AccountServiceImpl.kt
@@ -49,9 +49,6 @@ class AccountServiceImpl @Inject constructor() : AccountService {
     }
 
     override suspend fun signOut() {
-        if (Firebase.auth.currentUser!!.isAnonymous) {
-            Firebase.auth.currentUser!!.delete()
-        }
         Firebase.auth.signOut()
 
         // Sign the user back in anonymously.

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/impl/AccountServiceImpl.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/impl/AccountServiceImpl.kt
@@ -31,6 +31,10 @@ class AccountServiceImpl @Inject constructor() : AccountService {
         return Firebase.auth.currentUser != null
     }
 
+    override fun isAnonymousUser(): Boolean {
+        return Firebase.auth.currentUser?.isAnonymous ?: true
+    }
+
     override suspend fun createAnonymousAccount() {
         Firebase.auth.signInAnonymously().await()
     }

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/impl/AccountServiceImpl.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/model/service/impl/AccountServiceImpl.kt
@@ -33,12 +33,12 @@ class AccountServiceImpl @Inject constructor() : AccountService {
         return Firebase.auth.currentUser != null
     }
 
-    override suspend fun createAnonymousAccount() {
-        Firebase.auth.signInAnonymously().await()
+    override fun getUserProfile(): User {
+        return Firebase.auth.currentUser.toNotesUser()
     }
 
-    override suspend fun getUserProfile(): User {
-        return Firebase.auth.currentUser.toNotesUser()
+    override suspend fun createAnonymousAccount() {
+        Firebase.auth.signInAnonymously().await()
     }
 
     override suspend fun updateDisplayName(newDisplayName: String) {
@@ -46,7 +46,7 @@ class AccountServiceImpl @Inject constructor() : AccountService {
             displayName = newDisplayName
         }
 
-        Firebase.auth.currentUser!!.updateProfile(profileUpdates)
+        Firebase.auth.currentUser!!.updateProfile(profileUpdates).await()
     }
 
     override suspend fun linkAccount(email: String, password: String) {

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterCards.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterCards.kt
@@ -1,0 +1,163 @@
+package com.notes.app.screens.account_center
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.ExitToApp
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.notes.app.R
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun DisplayNameCard(displayName: String, onUpdateDisplayNameClick: (String) -> Unit) {
+    var showDisplayNameDialog by remember { mutableStateOf(false) }
+    var newDisplayName by remember { mutableStateOf(displayName) }
+
+    val cardTitle = displayName.ifBlank { stringResource(R.string.profile_name) }
+
+    AccountCenterCard(cardTitle, Icons.Filled.Edit, Modifier.card()) {
+        showDisplayNameDialog = true
+    }
+
+    if (showDisplayNameDialog) {
+        AlertDialog(
+            title = { Text(stringResource(R.string.profile_name)) },
+            text = {
+                Column {
+                    TextField(
+                        value = newDisplayName,
+                        onValueChange = { newDisplayName = it }
+                    )
+                }
+            },
+            dismissButton = {
+                Button(onClick = {
+                    showDisplayNameDialog = false
+                    newDisplayName = displayName
+                }) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    onUpdateDisplayNameClick(newDisplayName)
+                    showDisplayNameDialog = false
+                }) {
+                    Text(text = stringResource(R.string.update))
+                }
+            },
+            onDismissRequest = {
+                showDisplayNameDialog = false
+                newDisplayName = displayName
+            }
+        )
+    }
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun AccountCenterCard(
+    title: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+    onCardClick: () -> Unit
+) {
+    Card(
+        modifier = modifier,
+        onClick = onCardClick
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Column(modifier = Modifier.weight(1f)) { Text(title) }
+            Icon(icon, contentDescription = "Icon")
+        }
+    }
+}
+
+fun Modifier.card(): Modifier {
+    return this.padding(16.dp, 0.dp, 16.dp, 8.dp)
+}
+
+@Composable
+fun ExitAppCard(onSignOutClick: () -> Unit) {
+    var showExitAppDialog by remember { mutableStateOf(false) }
+
+    AccountCenterCard(stringResource(R.string.sign_out), Icons.Filled.ExitToApp, Modifier.card()) {
+        showExitAppDialog = true
+    }
+
+    if (showExitAppDialog) {
+        AlertDialog(
+            title = { Text(stringResource(R.string.sign_out_title)) },
+            text = { Text(stringResource(R.string.sign_out_description)) },
+            dismissButton = {
+                Button(onClick = { showExitAppDialog = false }) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    onSignOutClick()
+                    showExitAppDialog = false
+                }) {
+                    Text(text = stringResource(R.string.sign_out))
+                }
+            },
+            onDismissRequest = { showExitAppDialog = false }
+        )
+    }
+}
+
+@Composable
+fun RemoveAccountCard(onRemoveAccountClick: () -> Unit) {
+    var showRemoveAccDialog by remember { mutableStateOf(false) }
+
+    AccountCenterCard(stringResource(R.string.delete_account), Icons.Filled.Delete, Modifier.card()) {
+        showRemoveAccDialog = true
+    }
+
+    if (showRemoveAccDialog) {
+        AlertDialog(
+            title = { Text(stringResource(R.string.delete_account_title)) },
+            text = { Text(stringResource(R.string.delete_account_description)) },
+            dismissButton = {
+                Button(onClick = { showRemoveAccDialog = false }) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    onRemoveAccountClick()
+                    showRemoveAccDialog = false
+                }) {
+                    Text(text = stringResource(R.string.delete_account))
+                }
+            },
+            onDismissRequest = { showRemoveAccDialog = false }
+        )
+    }
+}

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterCards.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterCards.kt
@@ -36,6 +36,7 @@ fun DisplayNameCard(displayName: String, onUpdateDisplayNameClick: (String) -> U
     val cardTitle = displayName.ifBlank { stringResource(R.string.profile_name) }
 
     AccountCenterCard(cardTitle, Icons.Filled.Edit, Modifier.card()) {
+        newDisplayName =  displayName
         showDisplayNameDialog = true
     }
 
@@ -51,10 +52,7 @@ fun DisplayNameCard(displayName: String, onUpdateDisplayNameClick: (String) -> U
                 }
             },
             dismissButton = {
-                Button(onClick = {
-                    showDisplayNameDialog = false
-                    newDisplayName = displayName
-                }) {
+                Button(onClick = { showDisplayNameDialog = false }) {
                     Text(text = stringResource(R.string.cancel))
                 }
             },
@@ -66,10 +64,7 @@ fun DisplayNameCard(displayName: String, onUpdateDisplayNameClick: (String) -> U
                     Text(text = stringResource(R.string.update))
                 }
             },
-            onDismissRequest = {
-                showDisplayNameDialog = false
-                newDisplayName = displayName
-            }
+            onDismissRequest = { showDisplayNameDialog = false }
         )
     }
 }

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterScreen.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterScreen.kt
@@ -1,0 +1,176 @@
+package com.notes.app.screens.account_center
+
+import android.annotation.SuppressLint
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBox
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.ExitToApp
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.notes.app.R
+import com.notes.app.ui.theme.NotesTheme
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+fun AccountCenterScreen(
+    restartApp: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AccountCenterViewModel = hiltViewModel()
+) {
+    val isAnonymousAccount = viewModel.isAnonymousAccount.collectAsState()
+
+    Scaffold {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .fillMaxHeight(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            TopAppBar(title = { Text(stringResource(R.string.account_center)) })
+
+            Spacer(modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp))
+
+            if (isAnonymousAccount.value) {
+                AccountCenterCard(R.string.sign_in, Icons.Filled.Face, Modifier.card()) {
+                    viewModel.onSignInClick(restartApp)
+                }
+
+                AccountCenterCard(R.string.sign_up, Icons.Filled.AccountCircle, Modifier.card()) {
+                    viewModel.onSignUpClick(restartApp)
+                }
+            } else {
+                ExitAppCard { viewModel.onSignOutClick(restartApp) }
+                RemoveAccountCard { viewModel.onDeleteAccountClick(restartApp) }
+            }
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun AccountCenterCard(
+    @StringRes title: Int,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+    onCardClick: () -> Unit
+) {
+    Card(
+        modifier = modifier,
+        onClick = onCardClick
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Column(modifier = Modifier.weight(1f)) { Text(stringResource(title)) }
+            Icon(icon, contentDescription = "Icon")
+        }
+    }
+}
+
+private fun Modifier.card(): Modifier {
+    return this.padding(16.dp, 0.dp, 16.dp, 8.dp)
+}
+
+@Composable
+private fun ExitAppCard(onSignOutClick: () -> Unit) {
+    var showExitAppDialog by remember { mutableStateOf(false) }
+
+    AccountCenterCard(R.string.sign_out, Icons.Filled.ExitToApp, Modifier.card()) {
+        showExitAppDialog = true
+    }
+
+    if (showExitAppDialog) {
+        AlertDialog(
+            title = { Text(stringResource(R.string.sign_out_title)) },
+            text = { Text(stringResource(R.string.sign_out_description)) },
+            dismissButton = {
+                Button(onClick = { showExitAppDialog = false }) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    onSignOutClick()
+                    showExitAppDialog = false
+                }) {
+                    Text(text = stringResource(R.string.sign_out))
+                }
+            },
+            onDismissRequest = { showExitAppDialog = false }
+        )
+    }
+}
+
+@Composable
+private fun RemoveAccountCard(onRemoveAccountClick: () -> Unit) {
+    var showRemoveAccDialog by remember { mutableStateOf(false) }
+
+    AccountCenterCard(R.string.delete_account, Icons.Filled.Delete, Modifier.card()) {
+        showRemoveAccDialog = true
+    }
+
+    if (showRemoveAccDialog) {
+        AlertDialog(
+            title = { Text(stringResource(R.string.delete_account_title)) },
+            text = { Text(stringResource(R.string.delete_account_description)) },
+            dismissButton = {
+                Button(onClick = { showRemoveAccDialog = false }) {
+                    Text(text = stringResource(R.string.cancel))
+                }
+            },
+            confirmButton = {
+                Button(onClick = {
+                    onRemoveAccountClick()
+                    showRemoveAccDialog = false
+                }) {
+                    Text(text = stringResource(R.string.delete_account))
+                }
+            },
+            onDismissRequest = { showRemoveAccDialog = false }
+        )
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun AccountCenterPreview() {
+    NotesTheme {
+        AccountCenterScreen({ })
+    }
+}

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterScreen.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterScreen.kt
@@ -1,44 +1,32 @@
 package com.notes.app.screens.account_center
 
 import android.annotation.SuppressLint
-import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountBox
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.AddCircle
-import androidx.compose.material.icons.filled.Create
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material.icons.filled.Face
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.notes.app.R
+import com.notes.app.model.User
 import com.notes.app.ui.theme.NotesTheme
+import androidx.compose.runtime.*
+import java.util.Locale
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -48,7 +36,8 @@ fun AccountCenterScreen(
     modifier: Modifier = Modifier,
     viewModel: AccountCenterViewModel = hiltViewModel()
 ) {
-    val isAnonymousAccount = viewModel.isAnonymousAccount.collectAsState()
+    val user by viewModel.user.collectAsState(initial = User())
+    val provider = user.provider.replaceFirstChar { it.titlecase(Locale.getDefault()) }
 
     Scaffold {
         Column(
@@ -63,12 +52,43 @@ fun AccountCenterScreen(
                 .fillMaxWidth()
                 .padding(12.dp))
 
-            if (isAnonymousAccount.value) {
-                AccountCenterCard(R.string.sign_in, Icons.Filled.Face, Modifier.card()) {
+            DisplayNameCard(user.displayName) { viewModel.onUpdateDisplayNameClick(it) }
+
+            Spacer(modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp))
+
+            Card(modifier = Modifier.card()) {
+                Column(modifier = Modifier.fillMaxWidth().padding(top = 16.dp, start = 16.dp, end = 16.dp)) {
+                    if (!user.isAnonymous) {
+                        Text(
+                            text = String.format(stringResource(R.string.profile_email), user.email),
+                            modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)
+                        )
+                    }
+
+                    Text(
+                        text = String.format(stringResource(R.string.profile_uid), user.id),
+                        modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)
+                    )
+
+                    Text(
+                        text = String.format(stringResource(R.string.profile_provider), provider),
+                        modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp))
+
+            if (user.isAnonymous) {
+                AccountCenterCard(stringResource(R.string.sign_in), Icons.Filled.Face, Modifier.card()) {
                     viewModel.onSignInClick(restartApp)
                 }
 
-                AccountCenterCard(R.string.sign_up, Icons.Filled.AccountCircle, Modifier.card()) {
+                AccountCenterCard(stringResource(R.string.sign_up), Icons.Filled.AccountCircle, Modifier.card()) {
                     viewModel.onSignUpClick(restartApp)
                 }
             } else {
@@ -76,94 +96,6 @@ fun AccountCenterScreen(
                 RemoveAccountCard { viewModel.onDeleteAccountClick(restartApp) }
             }
         }
-    }
-}
-
-@Composable
-@OptIn(ExperimentalMaterial3Api::class)
-private fun AccountCenterCard(
-    @StringRes title: Int,
-    icon: ImageVector,
-    modifier: Modifier = Modifier,
-    onCardClick: () -> Unit
-) {
-    Card(
-        modifier = modifier,
-        onClick = onCardClick
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        ) {
-            Column(modifier = Modifier.weight(1f)) { Text(stringResource(title)) }
-            Icon(icon, contentDescription = "Icon")
-        }
-    }
-}
-
-private fun Modifier.card(): Modifier {
-    return this.padding(16.dp, 0.dp, 16.dp, 8.dp)
-}
-
-@Composable
-private fun ExitAppCard(onSignOutClick: () -> Unit) {
-    var showExitAppDialog by remember { mutableStateOf(false) }
-
-    AccountCenterCard(R.string.sign_out, Icons.Filled.ExitToApp, Modifier.card()) {
-        showExitAppDialog = true
-    }
-
-    if (showExitAppDialog) {
-        AlertDialog(
-            title = { Text(stringResource(R.string.sign_out_title)) },
-            text = { Text(stringResource(R.string.sign_out_description)) },
-            dismissButton = {
-                Button(onClick = { showExitAppDialog = false }) {
-                    Text(text = stringResource(R.string.cancel))
-                }
-            },
-            confirmButton = {
-                Button(onClick = {
-                    onSignOutClick()
-                    showExitAppDialog = false
-                }) {
-                    Text(text = stringResource(R.string.sign_out))
-                }
-            },
-            onDismissRequest = { showExitAppDialog = false }
-        )
-    }
-}
-
-@Composable
-private fun RemoveAccountCard(onRemoveAccountClick: () -> Unit) {
-    var showRemoveAccDialog by remember { mutableStateOf(false) }
-
-    AccountCenterCard(R.string.delete_account, Icons.Filled.Delete, Modifier.card()) {
-        showRemoveAccDialog = true
-    }
-
-    if (showRemoveAccDialog) {
-        AlertDialog(
-            title = { Text(stringResource(R.string.delete_account_title)) },
-            text = { Text(stringResource(R.string.delete_account_description)) },
-            dismissButton = {
-                Button(onClick = { showRemoveAccDialog = false }) {
-                    Text(text = stringResource(R.string.cancel))
-                }
-            },
-            confirmButton = {
-                Button(onClick = {
-                    onRemoveAccountClick()
-                    showRemoveAccDialog = false
-                }) {
-                    Text(text = stringResource(R.string.delete_account))
-                }
-            },
-            onDismissRequest = { showRemoveAccDialog = false }
-        )
     }
 }
 

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterViewModel.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterViewModel.kt
@@ -6,21 +6,19 @@ import com.notes.app.SPLASH_SCREEN
 import com.notes.app.model.service.AccountService
 import com.notes.app.screens.NotesAppViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import javax.inject.Inject
 
 @HiltViewModel
 class AccountCenterViewModel @Inject constructor(
     private val accountService: AccountService
 ) : NotesAppViewModel() {
-    // Backing properties to avoid state updates from other classes
-    private val _isAnonymousAccount = MutableStateFlow(true)
-    val isAnonymousAccount: StateFlow<Boolean> = _isAnonymousAccount.asStateFlow()
+    val user = accountService.currentUser.filterNotNull()
 
-    init {
-        _isAnonymousAccount.value = accountService.isAnonymousUser()
+    fun onUpdateDisplayNameClick(newDisplayName: String) {
+        launchCatching {
+            accountService.updateDisplayName(newDisplayName)
+        }
     }
 
     fun onSignInClick(openScreen: (String) -> Unit) = openScreen(SIGN_IN_SCREEN)

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterViewModel.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterViewModel.kt
@@ -1,0 +1,39 @@
+package com.notes.app.screens.account_center
+
+import com.notes.app.SIGN_IN_SCREEN
+import com.notes.app.SIGN_UP_SCREEN
+import com.notes.app.SPLASH_SCREEN
+import com.notes.app.model.service.AccountService
+import com.notes.app.screens.NotesAppViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class AccountCenterViewModel @Inject constructor(
+    private val accountService: AccountService
+) : NotesAppViewModel() {
+    // Backing properties to avoid state updates from other classes
+    private val _isAnonymousAccount = MutableStateFlow(true)
+    val isAnonymousAccount: StateFlow<Boolean> = _isAnonymousAccount.asStateFlow()
+
+    fun onSignInClick(openScreen: (String) -> Unit) = openScreen(SIGN_IN_SCREEN)
+
+    fun onSignUpClick(openScreen: (String) -> Unit) = openScreen(SIGN_UP_SCREEN)
+
+    fun onSignOutClick(restartApp: (String) -> Unit) {
+        launchCatching {
+            accountService.signOut()
+            restartApp(SPLASH_SCREEN)
+        }
+    }
+
+    fun onDeleteAccountClick(restartApp: (String) -> Unit) {
+        launchCatching {
+            accountService.deleteAccount()
+            restartApp(SPLASH_SCREEN)
+        }
+    }
+}

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterViewModel.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterViewModel.kt
@@ -3,21 +3,33 @@ package com.notes.app.screens.account_center
 import com.notes.app.SIGN_IN_SCREEN
 import com.notes.app.SIGN_UP_SCREEN
 import com.notes.app.SPLASH_SCREEN
+import com.notes.app.model.User
 import com.notes.app.model.service.AccountService
 import com.notes.app.screens.NotesAppViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 @HiltViewModel
 class AccountCenterViewModel @Inject constructor(
     private val accountService: AccountService
 ) : NotesAppViewModel() {
-    val user = accountService.currentUser.filterNotNull()
+    // Backing property to avoid state updates from other classes
+    private val _user = MutableStateFlow(User())
+    val user: StateFlow<User> = _user.asStateFlow()
+
+    init {
+        launchCatching {
+            _user.value = accountService.getUserProfile()
+        }
+    }
 
     fun onUpdateDisplayNameClick(newDisplayName: String) {
         launchCatching {
             accountService.updateDisplayName(newDisplayName)
+            _user.value = _user.value.copy(displayName = newDisplayName)
         }
     }
 

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterViewModel.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterViewModel.kt
@@ -29,7 +29,7 @@ class AccountCenterViewModel @Inject constructor(
     fun onUpdateDisplayNameClick(newDisplayName: String) {
         launchCatching {
             accountService.updateDisplayName(newDisplayName)
-            _user.value = _user.value.copy(displayName = newDisplayName)
+            _user.value = accountService.getUserProfile()
         }
     }
 

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterViewModel.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/account_center/AccountCenterViewModel.kt
@@ -19,6 +19,10 @@ class AccountCenterViewModel @Inject constructor(
     private val _isAnonymousAccount = MutableStateFlow(true)
     val isAnonymousAccount: StateFlow<Boolean> = _isAnonymousAccount.asStateFlow()
 
+    init {
+        _isAnonymousAccount.value = accountService.isAnonymousUser()
+    }
+
     fun onSignInClick(openScreen: (String) -> Unit) = openScreen(SIGN_IN_SCREEN)
 
     fun onSignUpClick(openScreen: (String) -> Unit) = openScreen(SIGN_UP_SCREEN)

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/note/NoteScreen.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/note/NoteScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -47,13 +48,20 @@ fun NoteScreen(
         .fillMaxWidth()
         .fillMaxHeight()) {
         TopAppBar(
-            title = { Text(note.value.getTitle()) },
+            title = {
+                Text(
+                    text = note.value.getTitle(),
+                    overflow = TextOverflow.Ellipsis,
+                    softWrap = false,
+                    maxLines = 1
+                )
+            },
             actions = {
                 IconButton(onClick = { viewModel.saveNote(popUpScreen) }) {
                     Icon(Icons.Filled.Done, "Save note")
                 }
                 IconButton(onClick = { viewModel.deleteNote(popUpScreen) }) {
-                    Icon(Icons.Filled.Delete, "Save note")
+                    Icon(Icons.Filled.Delete, "Delete note")
                 }
             }
         )

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/notes_list/NotesListScreen.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/notes_list/NotesListScreen.kt
@@ -13,9 +13,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ExitToApp
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -29,12 +27,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -44,7 +38,6 @@ import com.notes.app.model.Note
 import com.notes.app.model.getTitle
 import com.notes.app.ui.theme.NotesTheme
 import com.notes.app.ui.theme.Purple40
-import com.notes.app.ui.theme.PurpleGrey40
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -70,8 +63,6 @@ fun NotesListScreen(
         }
     ) {
         val notes by viewModel.notes.collectAsState(emptyList())
-        var showExitAppDialog by remember { mutableStateOf(false) }
-        var showRemoveAccDialog by remember { mutableStateOf(false) }
 
         Column(modifier = Modifier
             .fillMaxWidth()
@@ -79,15 +70,8 @@ fun NotesListScreen(
             TopAppBar(
                 title = { Text(stringResource(R.string.app_name)) },
                 actions = {
-                    IconButton(onClick = { showExitAppDialog = true }) {
-                        Icon(Icons.Filled.ExitToApp, "Exit app")
-                    }
-                    IconButton(onClick = { showRemoveAccDialog = true }) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.person_remove),
-                            contentDescription = "Remove account",
-                            tint = PurpleGrey40
-                        )
+                    IconButton(onClick = { viewModel.onAccountCenterClick(openScreen) }) {
+                        Icon(Icons.Filled.Person, "Account center")
                     }
                 }
             )
@@ -109,48 +93,6 @@ fun NotesListScreen(
                         )
                     }
                 }
-            }
-
-            if (showExitAppDialog) {
-                AlertDialog(
-                    title = { Text(stringResource(R.string.sign_out_title)) },
-                    text = { Text(stringResource(R.string.sign_out_description)) },
-                    dismissButton = {
-                        Button(onClick = { showExitAppDialog = false }) {
-                            Text(text = stringResource(R.string.cancel))
-                        }
-                    },
-                    confirmButton = {
-                        Button(onClick = {
-                            viewModel.onSignOutClick()
-                            showExitAppDialog = false
-                        }) {
-                            Text(text = stringResource(R.string.sign_out))
-                        }
-                    },
-                    onDismissRequest = { showExitAppDialog = false }
-                )
-            }
-
-            if (showRemoveAccDialog) {
-                AlertDialog(
-                    title = { Text(stringResource(R.string.delete_account_title)) },
-                    text = { Text(stringResource(R.string.delete_account_description)) },
-                    dismissButton = {
-                        Button(onClick = { showRemoveAccDialog = false }) {
-                            Text(text = stringResource(R.string.cancel))
-                        }
-                    },
-                    confirmButton = {
-                        Button(onClick = {
-                            viewModel.onDeleteAccountClick()
-                            showRemoveAccDialog = false
-                        }) {
-                            Text(text = stringResource(R.string.delete_account))
-                        }
-                    },
-                    onDismissRequest = { showRemoveAccDialog = false }
-                )
             }
         }
     }

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/notes_list/NotesListViewModel.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/notes_list/NotesListViewModel.kt
@@ -1,5 +1,6 @@
 package com.notes.app.screens.notes_list
 
+import com.notes.app.ACCOUNT_CENTER_SCREEN
 import com.notes.app.NOTE_DEFAULT_ID
 import com.notes.app.NOTE_ID
 import com.notes.app.NOTE_SCREEN
@@ -25,6 +26,7 @@ class NotesListViewModel @Inject constructor(
             }
         }
     }
+
     fun onAddClick(openScreen: (String) -> Unit) {
         openScreen("$NOTE_SCREEN?$NOTE_ID=$NOTE_DEFAULT_ID")
     }
@@ -33,15 +35,7 @@ class NotesListViewModel @Inject constructor(
         openScreen("$NOTE_SCREEN?$NOTE_ID=${note.id}")
     }
 
-    fun onSignOutClick() {
-        launchCatching {
-            accountService.signOut()
-        }
-    }
-
-    fun onDeleteAccountClick() {
-        launchCatching {
-            accountService.deleteAccount()
-        }
+    fun onAccountCenterClick(openScreen: (String) -> Unit) {
+        openScreen(ACCOUNT_CENTER_SCREEN)
     }
 }

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/CredentialsExt.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/CredentialsExt.kt
@@ -3,7 +3,7 @@ package com.notes.app.screens.sign_up
 import android.util.Patterns
 import java.util.regex.Pattern
 
-// Passwords should have at least six digits and include
+// Passwords must have at least six digits and include
 // one digit, one lower case letter and one upper case letter.
 private const val MIN_PASS_LENGTH = 6
 private const val PASS_PATTERN = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=\\S+$).{4,}$"

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/CredentialsExt.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/CredentialsExt.kt
@@ -1,0 +1,23 @@
+package com.notes.app.screens.sign_up
+
+import android.util.Patterns
+import java.util.regex.Pattern
+
+// Passwords should have at least six digits and include
+// one digit, one lower case letter and one upper case letter.
+private const val MIN_PASS_LENGTH = 6
+private const val PASS_PATTERN = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=\\S+$).{4,}$"
+
+fun String.isValidEmail(): Boolean {
+  return this.isNotBlank() && Patterns.EMAIL_ADDRESS.matcher(this).matches()
+}
+
+fun String.isValidPassword(): Boolean {
+  return this.isNotBlank() &&
+    this.length >= MIN_PASS_LENGTH &&
+    Pattern.compile(PASS_PATTERN).matcher(this).matches()
+}
+
+fun String.passwordMatches(repeated: String): Boolean {
+  return this == repeated
+}

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/CredentialsExt.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/CredentialsExt.kt
@@ -17,7 +17,3 @@ fun String.isValidPassword(): Boolean {
     this.length >= MIN_PASS_LENGTH &&
     Pattern.compile(PASS_PATTERN).matcher(this).matches()
 }
-
-fun String.passwordMatches(repeated: String): Boolean {
-  return this == repeated
-}

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/SignUpViewModel.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/SignUpViewModel.kt
@@ -39,15 +39,15 @@ class SignUpViewModel @Inject constructor(
     fun onSignUpClick(openAndPopUp: (String, String) -> Unit) {
         launchCatching {
             if (!_email.value.isValidEmail()) {
-                throw Exception("Invalid email format")
+                throw IllegalArgumentException("Invalid email format")
             }
 
             if (!_password.value.isValidPassword()) {
-                throw Exception("Invalid password format")
+                throw IllegalArgumentException("Invalid password format")
             }
 
-            if (!_password.value.passwordMatches(_confirmPassword.value)) {
-                throw Exception("Passwords do not match")
+            if (_password.value != _confirmPassword.value) {
+                throw IllegalArgumentException("Passwords do not match")
             }
 
             accountService.linkAccount(_email.value, _password.value)

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/SignUpViewModel.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/SignUpViewModel.kt
@@ -42,7 +42,7 @@ class SignUpViewModel @Inject constructor(
                 throw Exception("Passwords do not match")
             }
 
-            accountService.signUp(_email.value, _password.value)
+            accountService.linkAccount(_email.value, _password.value)
             openAndPopUp(NOTES_LIST_SCREEN, SIGN_UP_SCREEN)
         }
     }

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/SignUpViewModel.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/sign_up/SignUpViewModel.kt
@@ -38,7 +38,15 @@ class SignUpViewModel @Inject constructor(
 
     fun onSignUpClick(openAndPopUp: (String, String) -> Unit) {
         launchCatching {
-            if (_password.value != _confirmPassword.value) {
+            if (!_email.value.isValidEmail()) {
+                throw Exception("Invalid email format")
+            }
+
+            if (!_password.value.isValidPassword()) {
+                throw Exception("Invalid password format")
+            }
+
+            if (!_password.value.passwordMatches(_confirmPassword.value)) {
                 throw Exception("Passwords do not match")
             }
 

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/splash/SplashViewModel.kt
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/java/com/notes/app/screens/splash/SplashViewModel.kt
@@ -1,7 +1,6 @@
 package com.notes.app.screens.splash
 
 import com.notes.app.NOTES_LIST_SCREEN
-import com.notes.app.SIGN_IN_SCREEN
 import com.notes.app.SPLASH_SCREEN
 import com.notes.app.model.service.AccountService
 import com.notes.app.screens.NotesAppViewModel
@@ -15,6 +14,13 @@ class SplashViewModel @Inject constructor(
 
   fun onAppStart(openAndPopUp: (String, String) -> Unit) {
     if (accountService.hasUser()) openAndPopUp(NOTES_LIST_SCREEN, SPLASH_SCREEN)
-    else openAndPopUp(SIGN_IN_SCREEN, SPLASH_SCREEN)
+    else createAnonymousAccount(openAndPopUp)
+  }
+
+  private fun createAnonymousAccount(openAndPopUp: (String, String) -> Unit) {
+    launchCatching {
+      accountService.createAnonymousAccount()
+      openAndPopUp(NOTES_LIST_SCREEN, SPLASH_SCREEN)
+    }
   }
 }

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/res/drawable/person_remove.xml
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/res/drawable/person_remove.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M14,8c0,-2.21 -1.79,-4 -4,-4S6,5.79 6,8s1.79,4 4,4S14,10.21 14,8zM17,10v2h6v-2H17zM2,18v2h16v-2c0,-2.66 -5.33,-4 -8,-4S2,15.34 2,18z"/>
-</vector>

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/res/values/strings.xml
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/res/values/strings.xml
@@ -15,4 +15,9 @@
     <string name="delete_account_description">You will lose all your notes and your account will be deleted. This action is irreversible.</string>
     <string name="cancel">Cancel</string>
     <string name="account_center">Account center</string>
+    <string name="profile_name">Display name</string>
+    <string name="profile_email">Email: %1$s</string>
+    <string name="profile_uid">UID: %1$s</string>
+    <string name="profile_provider">Account provider: %1$s</string>
+    <string name="update">Update</string>
 </resources>

--- a/fundamentals/android/auth-anonymous/Notes/app/src/main/res/values/strings.xml
+++ b/fundamentals/android/auth-anonymous/Notes/app/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
     <string name="delete_account_title">Delete account?</string>
     <string name="delete_account_description">You will lose all your notes and your account will be deleted. This action is irreversible.</string>
     <string name="cancel">Cancel</string>
+    <string name="account_center">Account center</string>
 </resources>


### PR DESCRIPTION
This PR adds Anonymous Authentication to the Android sample app. The new authentication method is called from `AccountServiceImpl`, and used as soon as the app starts, in the `SplashScreen`. It also adds the Account Center screen, where the user can see their profile (email, uid, account provider and display name), update their display name, sign in to their account, or create a new account and link the existing Anonymous account to it. Once the user is signed in, the Account Center changes it's UI to reflect the new account options: sign out and delete account.

![non-anonymous-profile](https://github.com/FirebaseExtended/firebase-video-samples/assets/14080129/ae2f0789-32bb-427b-8194-9b7b56b441d5)
![anonymous_profile](https://github.com/FirebaseExtended/firebase-video-samples/assets/14080129/d7ca46ef-dd24-40ff-9896-a8b28334a886)
