### PR TITLE
FIX: uncaught exception from unsafe array access

### DIFF
--- a/fundamentals/apple/auth-account-linking/final/Favourites/Shared/Auth/UserProfileView.swift
+++ b/fundamentals/apple/auth-account-linking/final/Favourites/Shared/Auth/UserProfileView.swift
@@ -73,7 +73,7 @@ struct UserProfileView: View {
         VStack(alignment: .leading) {
           Text("Provider")
             .font(.caption)
-          Text(viewModel.user?.providerData[0].providerID ?? "(unknown)")
+            Text(viewModel.user?.providerData.first?.providerID ?? "(unknown)")
         }
         VStack(alignment: .leading) {
           Text("Anonymous / Guest user")

--- a/fundamentals/apple/auth-account-linking/final/Favourites/Shared/Auth/UserProfileView.swift
+++ b/fundamentals/apple/auth-account-linking/final/Favourites/Shared/Auth/UserProfileView.swift
@@ -73,7 +73,7 @@ struct UserProfileView: View {
         VStack(alignment: .leading) {
           Text("Provider")
             .font(.caption)
-            Text(viewModel.user?.providerData.first?.providerID ?? "(unknown)")
+          Text(viewModel.user?.providerData.first?.providerID ?? "(unknown)")
         }
         VStack(alignment: .leading) {
           Text("Anonymous / Guest user")


### PR DESCRIPTION
Fixes an issue #58 where repeatedly signing in and out can sometimes cause providerData to not have any items within the array, causing the app to crash with:

* Terminating app due to uncaught exception 'NSRangeException', reason: '*

This is a safety check to prevent that from happening.

![alt-text](https://i.giphy.com/3oKIPnAiaMCws8nOsE.webp)