### PR TITLE
FIX: Issue #58 persisted in fundamentals/apple/auth-email-link

### DIFF
--- a/fundamentals/apple/auth-email-link/final/Favourites/Shared/Auth/UserProfileView.swift
+++ b/fundamentals/apple/auth-email-link/final/Favourites/Shared/Auth/UserProfileView.swift
@@ -73,7 +73,7 @@ struct UserProfileView: View {
         VStack(alignment: .leading) {
           Text("Provider")
             .font(.caption)
-          Text(viewModel.user?.providerData[0].providerID ?? "(unknown)")
+          Text(viewModel.user?.providerData.first?.providerID ?? "(unknown)")
         }
         VStack(alignment: .leading) {
           Text("Anonymous / Guest user")


### PR DESCRIPTION
Fixes #58 in fundamentals/apple/auth-email-link

Fixes issue where repeatedly signing in and out of the app would cause it to crash.

![alt-text](https://i.giphy.com/JIX9t2j0ZTN9S.webp)