### PR TITLE
FIX: Sign in with apple does not dismiss LoginView

### DIFF
--- a/fundamentals/apple/auth-account-linking/final/Favourites/Shared/Auth/LoginView.swift
+++ b/fundamentals/apple/auth-account-linking/final/Favourites/Shared/Auth/LoginView.swift
@@ -135,6 +135,7 @@ struct LoginView: View {
         viewModel.handleSignInWithAppleRequest(request)
       } onCompletion: { result in
         viewModel.handleSignInWithAppleCompletion(result)
+        if case .success(_) = result { dismiss() }
       }
       .signInWithAppleButtonStyle(colorScheme == .light ? .black : .white)
       .frame(maxWidth: .infinity, minHeight: 50)


### PR DESCRIPTION
Fixes #53 
SignInWithAppleButton would not dismiss the LoginView

- Added dismiss on sucessful login.

![alt-text](https://i.giphy.com/mcsPU3SkKrYDdW3aAU.webp)