### PR TITLE
gemini-3-pro-preview --> gemini-3-flash-preview

### DIFF
--- a/firebase-ai-friendly-meals/apple/FriendlyMeals/FriendlyMeals/Features/Nutrition/ViewModels/NutritionViewModel.swift
+++ b/firebase-ai-friendly-meals/apple/FriendlyMeals/FriendlyMeals/Features/Nutrition/ViewModels/NutritionViewModel.swift
@@ -75,7 +75,7 @@ class NutritionViewModel {
 
     let ai = FirebaseAI.firebaseAI(backend: .googleAI())
     self.model = ai.generativeModel(
-      modelName: "gemini-3-pro-preview",
+      modelName: "gemini-3-flash-preview",
       generationConfig: generationConfig
     )
   }


### PR DESCRIPTION
The `gemini-3-pro-preview` model has been shutdown. And the use case we have here can certainly be done with gemini-3-flash, we don't need a Pro model for that.